### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/extension/deployment/src/main/java/org/acme/minecrafter/deployment/MinecrafterProcessor.java
+++ b/extension/deployment/src/main/java/org/acme/minecrafter/deployment/MinecrafterProcessor.java
@@ -12,7 +12,7 @@ import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 import jakarta.ws.rs.Priorities;
 import org.acme.minecrafter.runtime.HelloRecorder;
@@ -91,7 +91,7 @@ class MinecrafterProcessor {
                 Exception.class.getName(), Priorities.USER + 100, true);
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     public DevServicesResultBuildItem createContainer(LaunchModeBuildItem launchMode) {
         final int minecraftGamePort = 25565;
         final int minecraftApiPort = 8081;

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.13.1</quarkus.version>
+    <quarkus.version>3.20.0</quarkus.version>
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/extension/runtime/src/main/java/org/acme/minecrafter/runtime/MinecraftService.java
+++ b/extension/runtime/src/main/java/org/acme/minecrafter/runtime/MinecraftService.java
@@ -32,7 +32,7 @@ public class MinecraftService {
 
     public void log(String message) {
         try {
-            client.target(minecrafterConfig.baseURL)
+            client.target(minecrafterConfig.baseURL())
                   .path("observability/log")
                   .request(MediaType.TEXT_PLAIN)
                   .post(Entity.text(message));
@@ -48,10 +48,10 @@ public class MinecraftService {
 
     private void invokeMinecraftSynchronously(String path) {
         try {
-            String response = client.target(minecrafterConfig.baseURL)
+            String response = client.target(minecrafterConfig.baseURL())
                                     .path("observability/" + path)
                                     .request(MediaType.TEXT_PLAIN)
-                                    .post(Entity.text(minecrafterConfig.animalType))
+                                    .post(Entity.text(minecrafterConfig.animalType()))
                                     .readEntity(String.class);
 
             System.out.println("\uD83D\uDDE1️ [Minecrafter] Mod response: " + response);

--- a/extension/runtime/src/main/java/org/acme/minecrafter/runtime/MinecrafterConfig.java
+++ b/extension/runtime/src/main/java/org/acme/minecrafter/runtime/MinecrafterConfig.java
@@ -1,21 +1,23 @@
 package org.acme.minecrafter.runtime;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
-public class MinecrafterConfig {
+@ConfigMapping(prefix = "quarkus.minecrafter")
+public interface MinecrafterConfig {
 
     /**
      * The minecraft server's observability base URL
      */
-    @ConfigItem(defaultValue = "http://localhost:8081/")
-    public String baseURL;
+    @WithDefault("http://localhost:8081/")
+    String baseURL();
 
     /**
      * The kind of animal we spawn
      */
-    @ConfigItem(defaultValue = "chicken")
-    public String animalType;
+    @WithDefault("chicken")
+    String animalType();
 }

--- a/quarkus-todo-app/pom.xml
+++ b/quarkus-todo-app/pom.xml
@@ -16,12 +16,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <quarkus-plugin.version>3.13.1</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.13.1</quarkus.platform.version>
-
-    <testcontainers.version>1.16.3</testcontainers.version>
+    <quarkus.platform.version>3.24.4</quarkus.platform.version>
 
     <compiler-plugin.version>3.12.1</compiler-plugin.version>
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
@@ -78,13 +75,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -93,7 +88,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus-plugin.version}</version>
+        <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in 3.26 so we should avoid it.

> [!WARNING]
> Note that this requires to set the minimum version to 3.20, so you might have to have a maintenance branch for 3.15 if you want to push new versions supporting 3.15 after this is in.