### PR TITLE
Add custom Dev UI card with respawn buttons

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
@@ -96,13 +96,13 @@ class MinecrafterProcessor {
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 
-        cardPageBuildItem.addPage(Page
-                .webComponentPageBuilder()
-                .title("Game controls")
+        cardPageBuildItem.setCustomCard("qwc-minecraft-card.js");
+        cardPageBuildItem.setLogo("dark-chicken.png", "chicken.png");
+
+        cardPageBuildItem.addPage(Page.webComponentPageBuilder()
+                .title("Game Controls")
                 .icon("font-awesome-solid:gamepad")
                 .componentLink("qwc-minecraft-respawn.js"));
-
-        cardPageBuildItem.setLogo("dark-chicken.png", "chicken.png");
 
         cardsProducer.produce(cardPageBuildItem);
     }

--- a/deployment/src/main/resources/dev-ui/qwc-minecraft-card.js
+++ b/deployment/src/main/resources/dev-ui/qwc-minecraft-card.js
@@ -1,0 +1,122 @@
+import {LitElement, html, css} from 'lit';
+import {JsonRpc} from 'jsonrpc';
+import '@vaadin/button';
+import '@vaadin/icon';
+import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+
+export class QwcMinecraftCard extends LitElement {
+
+    jsonRpc = new JsonRpc(this);
+
+    static styles = css`
+        .card-content {
+            color: var(--lumo-contrast-80pct);
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-start;
+            padding: 10px 10px;
+            height: 100%;
+            font-size: var(--lumo-font-size-s);
+            gap: 10px;
+        }
+
+        .description {
+            padding-bottom: 10px;
+            color: var(--lumo-contrast-50pct);
+            line-height: 1.5;
+        }
+
+        .status-message {
+            padding: 10px;
+            border-radius: 4px;
+            background-color: var(--lumo-contrast-5pct);
+        }
+
+        .success {
+            color: var(--lumo-success-text-color);
+            background-color: var(--lumo-success-color-10pct);
+        }
+
+        .error {
+            color: var(--lumo-error-text-color);
+            background-color: var(--lumo-error-color-10pct);
+        }
+    `;
+
+    static properties = {
+        extensionName: {attribute: true},
+        description: {attribute: true},
+        guide: {attribute: true},
+        namespace: {attribute: true},
+        logoUrl: {attribute: true},
+        _statusMessage: {state: true},
+        _statusType: {state: true},
+        _playerDead: {state: true}
+    };
+
+    constructor() {
+        super();
+        this._statusMessage = '';
+        this._statusType = '';
+        this._playerDead = false;
+    }
+
+    render() {
+        return html`<div class="card-content" slot="content">
+            <div class="description">
+                ${this.logoUrl ? html`<img src="${this.logoUrl}" height="45" style="float: left; margin-right: 10px;" @error="${(e) => e.target.style.display = 'none'}">` : ''}
+                ${this.description}
+            </div>
+            <vaadin-button theme="primary small" @click="${this._setRespawn}">
+                <vaadin-icon icon="vaadin:flag" slot="prefix"></vaadin-icon>
+                Set A New Spawn Point
+            </vaadin-button>
+            <vaadin-button theme="primary small" @click="${this._killAndRespawnPlayer}">
+                <vaadin-icon icon="vaadin:play" slot="prefix"></vaadin-icon>
+                Respawn
+            </vaadin-button>
+            ${this._statusMessage ? html`
+                <div class="status-message ${this._statusType}">
+                    ${this._statusMessage}
+                </div>
+            ` : ''}
+        </div>`;
+    }
+
+    _setRespawn() {
+        this._statusMessage = 'Setting respawn point...';
+        this._statusType = '';
+
+        this.jsonRpc.setRespawn().then(() => {
+            this._statusMessage = 'Respawn point set ...';
+            this._statusType = 'success';
+        }).catch(error => {
+            this._statusMessage = `Error: ${error.message || 'Failed to set a new respawn point'}`;
+            this._statusType = 'error';
+        });
+    }
+
+    _killAndRespawnPlayer() {
+        this._statusMessage = 'Killing player...';
+        this._statusType = '';
+        return this.jsonRpc.killPlayer().then(() => {
+            this._playerDead = true;
+            this._statusMessage = 'Player killed — respawning ...';
+            this._statusType = 'success';
+            return this.jsonRpc.respawnPlayer();
+        }).then(() => {
+            this._statusMessage = 'Player respawned at new location';
+            this._statusType = 'success';
+            this._playerDead = false;
+            setTimeout(() => {
+                this._statusMessage = '';
+                this._statusType = '';
+            }, 3000);
+        }).catch(error => {
+            this._statusMessage = `Error: ${error.message || 'Failed to respawn'}`;
+            this._statusType = 'error';
+        });
+    }
+}
+
+customElements.define('qwc-minecraft-card', QwcMinecraftCard);


### PR DESCRIPTION
## Summary
- Move game control buttons (Set Spawn Point, Respawn) onto the extension card face using `setCustomCard()` API
- Add chicken logo rendering to the custom card component
- Keep the Game Controls page as a fallback navigation target (this seemed to be necessary to make the custom card render, which was surprising to me)

## Test plan
- [X] Run `quarkus:dev` in the sample app
- [X] Open Dev UI at `/q/dev-ui` and verify the Minecraft card shows buttons and chicken logo
- [X] Click "Set A New Spawn Point" and verify status message appears
- [X] Click "Respawn" and verify kill → respawn sequence works
- [X] Click the card to navigate to the Game Controls page and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)