### PR TITLE
Do not respawn over water by default, but make it configurable

### DIFF
--- a/modded-minecraft/src/main/java/com/example/examplemod/Endpoint.java
+++ b/modded-minecraft/src/main/java/com/example/examplemod/Endpoint.java
@@ -38,7 +38,7 @@ public class Endpoint {
 
     @POST
     @Path("/event")
-    @Consumes("text/plain")
+    @Consumes("application/json")
     public String simpleAlert(String type) {
         System.out.println("[Quarkcraft] event" + type);
         return invokeOnPlayer("event", "A thing happened out in the real world", type);
@@ -54,9 +54,10 @@ public class Endpoint {
 
     @POST
     @Path("/set-respawn")
-    public String setRespawn() {
+    @Consumes("application/json")
+    public String setRespawn(String config) {
         System.out.println("[Quarkcraft] set-respawn");
-        return invokeOnPlayer("setRespawn", "Respawn point updated", null);
+        return invokeOnPlayer("setRespawn", "Respawn point updated", config);
     }
 
     @POST

--- a/modded-minecraft/src/main/java/com/example/examplemod/PlayerWrapper.java
+++ b/modded-minecraft/src/main/java/com/example/examplemod/PlayerWrapper.java
@@ -33,6 +33,7 @@ import net.minecraft.world.phys.Vec3;
  * invoke the method by reflection.
  */
 public class PlayerWrapper {
+    private static final int MAX_RESPAWN_ATTEMPTS = 20;
     public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss");
     private final Player player;
     ObjectMapper objectMapper;
@@ -153,37 +154,55 @@ public class PlayerWrapper {
         }
     }
 
-    public void setRespawn(String message, String ignored) {
+    public void setRespawn(String message, String config) {
+        boolean allowWater = Boolean.parseBoolean(config);
         player.displayClientMessage(Component.literal(message), true);
 
         Level level = player.getLevel();
         if (level instanceof ServerLevel serverLevel && player instanceof ServerPlayer serverPlayer) {
-            // Pick a random direction and go 300-500 blocks away
-            double angle = Math.random() * 2 * Math.PI;
-            int distance = 300 + (int) (Math.random() * 200);
-            int targetX = (int) (player.getX() + Math.cos(angle) * distance);
-            int targetZ = (int) (player.getZ() + Math.sin(angle) * distance);
-
             // Must run on the server thread — this method is called from an
             // Undertow HTTP thread, and setRespawnPosition must be visible to
             // the death/respawn processing that happens later.
             serverLevel.getServer().execute(() -> {
-                // Force the target chunk to load so terrain is generated and
-                // the heightmap is available — avoids crashes from unknown chunks
-                serverLevel.getChunk(targetX >> 4, targetZ >> 4);
+                // Skip retries when water is acceptable
+                int maxAttempts = allowWater ? 1 : MAX_RESPAWN_ATTEMPTS;
+                BlockPos spawnPosition = null;
+                int chosenDistance = 0;
+                boolean isWater = false;
 
-                // Find a safe surface Y using the heightmap, then scan upward
-                // until we find two clear blocks for the player to stand in.
-                // Minecraft's respawn logic rejects positions without headroom.
-                int y = serverLevel.getHeight(Heightmap.Types.MOTION_BLOCKING, targetX, targetZ);
-                while (y < serverLevel.getMaxBuildHeight() - 1
-                        && (!serverLevel.getBlockState(new BlockPos(targetX, y, targetZ))
-                                .getCollisionShape(serverLevel, new BlockPos(targetX, y, targetZ)).isEmpty()
-                                || !serverLevel.getBlockState(new BlockPos(targetX, y + 1, targetZ))
-                                        .getCollisionShape(serverLevel, new BlockPos(targetX, y + 1, targetZ)).isEmpty())) {
-                    y++;
+                for (int attempt = 0; attempt < maxAttempts; attempt++) {
+                    // Pick a random direction and go 300-500 blocks away
+                    double angle = Math.random() * 2 * Math.PI;
+                    int distance = 300 + (int) (Math.random() * 200);
+                    int targetX = (int) (player.getX() + Math.cos(angle) * distance);
+                    int targetZ = (int) (player.getZ() + Math.sin(angle) * distance);
+
+                    // Force the target chunk to load so terrain is generated and
+                    // the heightmap is available — avoids crashes from unknown chunks
+                    serverLevel.getChunk(targetX >> 4, targetZ >> 4);
+
+                    // Find a safe surface Y using the heightmap, then scan upward
+                    // until we find two clear blocks for the player to stand in.
+                    // Minecraft's respawn logic rejects positions without headroom.
+                    int y = serverLevel.getHeight(Heightmap.Types.MOTION_BLOCKING, targetX, targetZ);
+                    while (y < serverLevel.getMaxBuildHeight() - 1
+                            && (!serverLevel.getBlockState(new BlockPos(targetX, y, targetZ))
+                                    .getCollisionShape(serverLevel, new BlockPos(targetX, y, targetZ)).isEmpty()
+                                    || !serverLevel.getBlockState(new BlockPos(targetX, y + 1, targetZ))
+                                            .getCollisionShape(serverLevel, new BlockPos(targetX, y + 1, targetZ))
+                                            .isEmpty())) {
+                        y++;
+                    }
+
+                    spawnPosition = new BlockPos(targetX, y, targetZ);
+                    chosenDistance = distance;
+
+                    isWater = !serverLevel.getBlockState(new BlockPos(targetX, y - 1, targetZ)).getFluidState()
+                            .isEmpty();
+                    if (allowWater || !isWater) {
+                        break;
+                    }
                 }
-                BlockPos spawnPosition = new BlockPos(targetX, y, targetZ);
 
                 serverPlayer.setRespawnPosition(
                         serverLevel.dimension(),
@@ -192,8 +211,16 @@ public class PlayerWrapper {
                         true,
                         false);
 
+                String biome = serverLevel.getBiome(spawnPosition).unwrapKey()
+                        .map(key -> key.location().getPath())
+                        .orElse("unknown");
+                String warning = isWater
+                        ? " (no dry land found after " + MAX_RESPAWN_ATTEMPTS + " attempts — respawn is over water)"
+                        : "";
                 player.displayClientMessage(
-                        Component.literal("Respawn set " + distance + " blocks away at: " + spawnPosition.toShortString()),
+                        Component.literal(
+                                "Respawn set " + chosenDistance + " blocks away in " + biome + " at: "
+                                        + spawnPosition.toShortString() + warning),
                         false);
             });
         }

--- a/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecraftService.java
+++ b/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecraftService.java
@@ -9,8 +9,6 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 
-import io.quarkiverse.observability.minecraft.runtime.ai.WuffStuff;
-
 @Singleton
 public class MinecraftService {
 
@@ -40,7 +38,7 @@ public class MinecraftService {
     }
 
     public String setRespawn() {
-        invokeMinecraft("set-respawn");
+        invokeMinecraft("set-respawn", String.valueOf(minecrafterConfig.allowRespawnOverWater()));
         return "Respawn point set to a new location";
     }
 
@@ -70,30 +68,20 @@ public class MinecraftService {
         executor.submit(() -> invokeMinecraftSynchronously(path));
     }
 
-    private void invokeMinecraft(String path, WuffStuff wuffStuff) {
-        executor.submit(() -> invokeMinecraftSynchronously(path, wuffStuff));
+    private void invokeMinecraft(String path, Object body) {
+        executor.submit(() -> invokeMinecraftSynchronously(path, body));
     }
 
     private void invokeMinecraftSynchronously(String path) {
-        try {
-            String response = client.target(minecrafterConfig.baseURL())
-                    .path("observability/" + path)
-                    .request(MediaType.TEXT_PLAIN)
-                    .post(Entity.text(minecrafterConfig.animalType()))
-                    .readEntity(String.class);
-
-            System.out.println("\uD83D\uDDE1️ [Minecrafter] Mod response: " + response);
-        } catch (Throwable e) {
-            System.out.println("\uD83D\uDDE1️ [Minecrafter] Connection error: " + e);
-        }
+        invokeMinecraftSynchronously(path, minecrafterConfig.animalType());
     }
 
-    private void invokeMinecraftSynchronously(String path, WuffStuff stuff) {
+    private void invokeMinecraftSynchronously(String path, Object body) {
         try {
             String response = client.target(minecrafterConfig.baseURL())
                     .path("observability/" + path)
                     .request(MediaType.APPLICATION_JSON)
-                    .post(Entity.json(stuff))
+                    .post(Entity.json(body))
                     .readEntity(String.class);
 
             System.out.println("\uD83D\uDDE1️ [Minecrafter] Mod response: " + response);

--- a/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecrafterConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecrafterConfig.java
@@ -24,6 +24,12 @@ public interface MinecrafterConfig {
     String animalType();
 
     /**
+     * Whether to allow respawn points over water.
+     */
+    @WithDefault("false")
+    boolean allowRespawnOverWater();
+
+    /**
      * Details of the LLM used for generating creatures.
      */
     Model model();


### PR DESCRIPTION

- Add `allowRespawnOverWater` config option (default: `false`) that controls whether respawn points can land over water
- Retry up to 20 times to find dry land when water is not allowed, with biome name and warning in the respawn message
- Unify the HTTP client to use `application/json` consistently and remove duplicate `invokeMinecraftSynchronously` overload

🤖 Generated with [Claude Code](https://claude.com/claude-code)