### PR TITLE
Make Minecraft dev services port configurable

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecraftContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecraftContainer.java
@@ -2,6 +2,7 @@ package io.quarkiverse.observability.minecraft.deployment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -16,18 +17,18 @@ public class MinecraftContainer extends GenericContainer<MinecraftContainer> imp
     private static final DockerImageName dockerImageName = DockerImageName.parse("minecraft-server");
     private final int minecraftApiPort;
 
-    public MinecraftContainer(final int minecraftApiPort) {
+    public MinecraftContainer(final int minecraftApiPort, Optional<Integer> devServicesPort) {
         super(dockerImageName);
         this.minecraftApiPort = minecraftApiPort;
         this.waitingFor(Wait.forLogMessage(".*" + "Preparing" + ".*", 1))
                 .withReuse(true)
                 .withExposedPorts(minecraftApiPort, minecraftGamePort);
 
-        // Make life easy for the minecraft client by fixing the client port
-        // This could be configurable
-        List<String> portBindings = new ArrayList<>();
-        portBindings.add(minecraftGamePort + ":" + minecraftGamePort);
-        this.setPortBindings(portBindings);
+        devServicesPort.ifPresent(port -> {
+            List<String> portBindings = new ArrayList<>();
+            portBindings.add(port + ":" + minecraftGamePort);
+            this.setPortBindings(portBindings);
+        });
 
     }
 

--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterDevServicesConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterDevServicesConfig.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.observability.minecraft.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.minecrafter")
+public interface MinecrafterDevServicesConfig {
+
+    /**
+     * Dev Services configuration.
+     */
+    DevServices devservices();
+
+    interface DevServices {
+        /**
+         * Fixed host port to expose the Minecraft game server on.
+         * If not set, an ephemeral host port is used.
+         */
+        Optional<Integer> port();
+    }
+}
+
+// Made with Bob

--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
@@ -114,13 +114,13 @@ class MinecrafterProcessor {
     }
 
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
-    public DevServicesResultBuildItem createContainer() {
+    public DevServicesResultBuildItem createContainer(MinecrafterDevServicesConfig config) {
 
         final int minecraftApiPort = 8081;
 
         return DevServicesResultBuildItem.owned()
                 .feature(FEATURE)
-                .startable(() -> new MinecraftContainer(minecraftApiPort))
+                .startable(() -> new MinecraftContainer(minecraftApiPort, config.devservices().port()))
                 .configProvider(Map.of("quarkus.minecrafter.base-url",
                         c -> "http://" + c.getHost() + ":" + c.getMappedPort(minecraftApiPort)))
                 .build();

--- a/sample/src/main/resources/application.properties
+++ b/sample/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.log.sql=false
 quarkus.application.name=myservice
+quarkus.minecrafter.devservices.port=25565
 #quarkus.minecrafter.animal-type=pig
 #quarkus.minecrafter.model.base-url=http://localhost:11434/v1/
 #quarkus.minecrafter.model.base-url=https://api.openai.com/v1/


### PR DESCRIPTION
For most uses, the well-known Minecraft port is most convenient, because we don't control the minecraft client. However, when running tests, one laptop and CI is fine, but the other laptop kept failing with port conflicts; maybe the tests were running faster than ryuk could keep up? Using random ports fixes the problem. 