### PR TITLE
Fix errors about MessageLogWriter by accepting correct response type

### DIFF
--- a/modded-minecraft/src/main/java/com/example/examplemod/Endpoint.java
+++ b/modded-minecraft/src/main/java/com/example/examplemod/Endpoint.java
@@ -27,7 +27,6 @@ public class Endpoint {
     @POST
     @Path("/event-with-details")
     @Consumes("application/json")
-    //    @Produces("text/plain")
     public String alert(String config) {
         System.out.println("[Quarkcraft] " + config);
         String name = invokeOnPlayer("customEvent", "A thing happened out in the real world",

--- a/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecraftService.java
+++ b/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecraftService.java
@@ -80,7 +80,7 @@ public class MinecraftService {
         try {
             String response = client.target(minecrafterConfig.baseURL())
                     .path("observability/" + path)
-                    .request(MediaType.APPLICATION_JSON)
+                    .request(MediaType.TEXT_PLAIN)
                     .post(Entity.json(body))
                     .readEntity(String.class);
 


### PR DESCRIPTION
We used to get warnings like this:

```
🗡️ [Minecrafter] Mod response: [minecraft servlet] Could not find MessageBodyWriter for response object of type: java.lang.String of media type: application/json
```

Bob says "The error occurred because the client was requesting application/json responses,
but the server endpoints had no @Produces annotation and the custom
PlainStringMessageBodyWriter only handles text/plain media type."

I'm surprised `request` is about the response, but changing the type there does indeed fix the error.  `request(types)` is equivalent to `request().accept(types)`.