### PR TITLE
Fix interceptor priority warning

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecraftLogInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/observability/minecraft/runtime/MinecraftLogInterceptor.java
@@ -3,12 +3,14 @@ package io.quarkiverse.observability.minecraft.runtime;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
 @MinecraftLog
 @Interceptor
+@Priority(Interceptor.Priority.LIBRARY_AFTER)
 public class MinecraftLogInterceptor {
     private final MinecraftService minecraft;
 


### PR DESCRIPTION
## Summary
Adds @Priority annotation to MinecraftLogInterceptor to resolve the warning:
`The interceptor does not declare any @Priority. It will be assigned a default priority value of 0.`

## Changes
- Added `@Priority(Interceptor.Priority.LIBRARY_AFTER)` annotation to MinecraftLogInterceptor
- Priority value of 3000 ensures this interceptor runs after library-level interceptors
- This is appropriate for observability concerns that should run after core application logic

## Testing
- Verified the warning no longer appears during application startup
- Interceptor continues to function correctly with explicit priority