### PR TITLE
Make world smaller and respect world border for respawn

### DIFF
--- a/modded-minecraft/Dockerfile
+++ b/modded-minecraft/Dockerfile
@@ -13,7 +13,7 @@ FROM webhippie/minecraft-forge:43.0
 # This is needed for the client launched with `./gradlew runClient` to be able to connect
 ENV MINECRAFT_ONLINE_MODE=false
 # For performance reasons, keep the world small
-ENV MINECRAFT_MAX_WORLD_SIZE=299
+ENV MINECRAFT_MAX_WORLD_SIZE=288
 
 EXPOSE 8081
 

--- a/modded-minecraft/build.gradle
+++ b/modded-minecraft/build.gradle
@@ -146,6 +146,8 @@ dependencies {
 
     implementation "io.undertow:undertow-core:2.2.17.Final"
 
+    testImplementation "org.junit.jupiter:junit-jupiter:5.9.3"
+
     // Examples using mod jars from ./libs
     // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
 
@@ -197,6 +199,10 @@ publishing {
             url "file://${project.projectDir}/mcmodsrepo"
         }
     }
+}
+
+test {
+    useJUnitPlatform()
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/modded-minecraft/pom.xml
+++ b/modded-minecraft/pom.xml
@@ -67,6 +67,16 @@
                   <skipMain>true</skipMain>
                 </configuration>
               </execution>
+              <execution>
+                <id>default-testCompile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
 

--- a/modded-minecraft/src/main/java/com/example/examplemod/PlayerWrapper.java
+++ b/modded-minecraft/src/main/java/com/example/examplemod/PlayerWrapper.java
@@ -178,33 +178,37 @@ public class PlayerWrapper {
             boolean isWater = false;
 
             for (int attempt = 0; attempt < maxAttempts; attempt++) {
-                // Pick a random direction and go 300-500 blocks away
+                // Pick a random direction, choosing a distance based on the max world size.
+                // Note: getAbsoluteMaxWorldSize() returns the max-world-size server property
+                // (a radius), NOT WorldBorder.getSize() which defaults to ~60M regardless.
+                int maxWorldRadius = serverLevel.getServer().getAbsoluteMaxWorldSize();
+                SpawnLocationHelper.DistanceRange range = SpawnLocationHelper.computeRespawnDistanceRange(maxWorldRadius * 2.0);
                 double angle = Math.random() * 2 * Math.PI;
-                int distance = 300 + (int) (Math.random() * 200);
-                int targetX = (int) (player.getX() + Math.cos(angle) * distance);
-                int targetZ = (int) (player.getZ() + Math.sin(angle) * distance);
+                int distance = range.min() + (int) (Math.random() * Math.max(1, range.max() - range.min()));
+                BlockPos target = SpawnLocationHelper.computeTargetPosition(player.getX(), player.getZ(),
+                        angle, distance, maxWorldRadius);
 
                 // Force the target chunk to load so terrain is generated and
                 // the heightmap is available — avoids crashes from unknown chunks
-                serverLevel.getChunk(targetX >> 4, targetZ >> 4);
+                serverLevel.getChunk(target.getX() >> 4, target.getZ() >> 4);
 
                 // Find a safe surface Y using the heightmap, then scan upward
                 // until we find two clear blocks for the player to stand in.
                 // Minecraft's respawn logic rejects positions without headroom.
-                int y = serverLevel.getHeight(Heightmap.Types.MOTION_BLOCKING, targetX, targetZ);
+                int y = serverLevel.getHeight(Heightmap.Types.MOTION_BLOCKING, target.getX(), target.getZ());
                 while (y < serverLevel.getMaxBuildHeight() - 1
-                        && (!serverLevel.getBlockState(new BlockPos(targetX, y, targetZ))
-                                .getCollisionShape(serverLevel, new BlockPos(targetX, y, targetZ)).isEmpty()
-                                || !serverLevel.getBlockState(new BlockPos(targetX, y + 1, targetZ))
-                                        .getCollisionShape(serverLevel, new BlockPos(targetX, y + 1, targetZ))
+                        && (!serverLevel.getBlockState(new BlockPos(target.getX(), y, target.getZ()))
+                                .getCollisionShape(serverLevel, new BlockPos(target.getX(), y, target.getZ())).isEmpty()
+                                || !serverLevel.getBlockState(new BlockPos(target.getX(), y + 1, target.getZ()))
+                                        .getCollisionShape(serverLevel, new BlockPos(target.getX(), y + 1, target.getZ()))
                                         .isEmpty())) {
                     y++;
                 }
 
-                spawnPosition = new BlockPos(targetX, y, targetZ);
+                spawnPosition = new BlockPos(target.getX(), y, target.getZ());
                 chosenDistance = distance;
 
-                isWater = !serverLevel.getBlockState(new BlockPos(targetX, y - 1, targetZ)).getFluidState()
+                isWater = !serverLevel.getBlockState(new BlockPos(target.getX(), y - 1, target.getZ())).getFluidState()
                         .isEmpty();
                 if (allowWater || !isWater) {
                     break;
@@ -249,12 +253,9 @@ public class PlayerWrapper {
 
     @NotNull
     private Vec3 getPositionInFrontOfPlayer(int distance) {
-        double x = player.getX() + distance * player.getLookAngle().x;
-        double y = player.getY() + distance; // Spawn at the same height as the player, but a bit up in the air
-        double z = player.getZ() + distance * player.getLookAngle().z;
-
-        Vec3 pos = new Vec3(x, y, z);
-        return pos;
+        return SpawnLocationHelper.computePositionInFrontOf(
+                player.getX(), player.getY(), player.getZ(),
+                player.getLookAngle().x, player.getLookAngle().z, distance);
     }
 
 }

--- a/modded-minecraft/src/main/java/com/example/examplemod/SpawnLocationHelper.java
+++ b/modded-minecraft/src/main/java/com/example/examplemod/SpawnLocationHelper.java
@@ -1,0 +1,52 @@
+package com.example.examplemod;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Pure-math helpers for computing spawn locations.
+ */
+final class SpawnLocationHelper {
+
+    record DistanceRange(int min, int max) {
+    }
+
+    private SpawnLocationHelper() {
+    }
+
+    /**
+     * Compute the min and max respawn distance from the world diameter.
+     */
+    static DistanceRange computeRespawnDistanceRange(double worldDiameter) {
+        int maxDistance = Math.max(1, (int) (worldDiameter / 2.0 * 0.7));
+        int minDistance = Math.min(30, maxDistance);
+        return new DistanceRange(minDistance, maxDistance);
+    }
+
+    /**
+     * Compute a target XZ block position offset from the player by the given angle
+     * and distance, clamped to stay within the max world radius.
+     * The returned BlockPos has y=0.
+     */
+    static BlockPos computeTargetPosition(double playerX, double playerZ, double angle, int distance,
+            int maxWorldRadius) {
+        int targetX = (int) (playerX + Math.cos(angle) * distance);
+        int targetZ = (int) (playerZ + Math.sin(angle) * distance);
+        targetX = Math.max(-maxWorldRadius + 1, Math.min(maxWorldRadius - 1, targetX));
+        targetZ = Math.max(-maxWorldRadius + 1, Math.min(maxWorldRadius - 1, targetZ));
+        return new BlockPos(targetX, 0, targetZ);
+    }
+
+    /**
+     * Compute a position in front of the player for spawning entities (chickens,
+     * frogs, etc.). X and Z are offset along the player's look direction; Y is
+     * raised by {@code distance} blocks above the player.
+     */
+    static Vec3 computePositionInFrontOf(double playerX, double playerY, double playerZ,
+            double lookAngleX, double lookAngleZ, int distance) {
+        double x = playerX + distance * lookAngleX;
+        double y = playerY + distance;
+        double z = playerZ + distance * lookAngleZ;
+        return new Vec3(x, y, z);
+    }
+}

--- a/modded-minecraft/src/test/java/com/example/examplemod/SpawnLocationHelperTest.java
+++ b/modded-minecraft/src/test/java/com/example/examplemod/SpawnLocationHelperTest.java
@@ -1,0 +1,207 @@
+package com.example.examplemod;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+
+class SpawnLocationHelperTest {
+
+    private static final int CONFIGURED_MAX_WORLD_RADIUS = 288;
+    private static final double DEFAULT_WORLD_BORDER_SIZE = 59_999_968;
+
+    // --- computeRespawnDistanceRange ---
+
+    @Nested
+    class RespawnDistanceRange {
+
+        @Test
+        void reasonableForConfiguredWorldSize() {
+            SpawnLocationHelper.DistanceRange range = SpawnLocationHelper
+                    .computeRespawnDistanceRange(CONFIGURED_MAX_WORLD_RADIUS * 2.0);
+
+            // diameter 576: maxDistance = (int)(576 / 2 * 0.7) = 201
+            assertTrue(range.max() <= 250,
+                    "Max respawn distance should be <= 250, but was " + range.max());
+            assertTrue(range.min() <= range.max(),
+                    "Min distance should be <= max distance");
+        }
+
+        @Test
+        void defaultWorldBorderProducesAbsurdDistances() {
+            // Documents the bug: WorldBorder.getSize() (~60M) must not be used.
+            SpawnLocationHelper.DistanceRange range = SpawnLocationHelper
+                    .computeRespawnDistanceRange(DEFAULT_WORLD_BORDER_SIZE);
+
+            assertTrue(range.max() > 1_000_000,
+                    "With the default world border (~60M), max distance should be millions, "
+                            + "demonstrating why the caller must use getAbsoluteMaxWorldSize(). "
+                            + "Got: " + range.max());
+        }
+
+        @Test
+        void minDistanceCapsAt30() {
+            SpawnLocationHelper.DistanceRange range = SpawnLocationHelper.computeRespawnDistanceRange(1000);
+            assertEquals(30, range.min());
+        }
+
+        @Test
+        void verySmallWorldClampsMinToMax() {
+            // diameter 20: maxDistance = (int)(20 / 2 * 0.7) = 7
+            SpawnLocationHelper.DistanceRange range = SpawnLocationHelper.computeRespawnDistanceRange(20);
+            assertEquals(7, range.min(), "minDistance should equal maxDistance for tiny worlds");
+            assertEquals(7, range.max());
+        }
+    }
+
+    // --- computeTargetPosition ---
+
+    @Nested
+    class TargetPosition {
+
+        @Test
+        void offsetFromOriginEast() {
+            BlockPos pos = SpawnLocationHelper.computeTargetPosition(0, 0, 0, 100, CONFIGURED_MAX_WORLD_RADIUS);
+            assertEquals(100, pos.getX(), "X should be offset by distance when angle is 0 (east)");
+            assertEquals(0, pos.getZ(), "Z should be unchanged when angle is 0");
+        }
+
+        @Test
+        void offsetFromOriginSouth() {
+            BlockPos pos = SpawnLocationHelper.computeTargetPosition(0, 0, Math.PI / 2, 100,
+                    CONFIGURED_MAX_WORLD_RADIUS);
+            assertTrue(Math.abs(pos.getX()) <= 1, "X should be ~0 when moving south, but was " + pos.getX());
+            assertEquals(100, pos.getZ(), "Z should be offset by distance when angle is PI/2 (south)");
+        }
+
+        @Test
+        void offsetFromNonOriginPlayer() {
+            BlockPos pos = SpawnLocationHelper.computeTargetPosition(50, 50, 0, 100, CONFIGURED_MAX_WORLD_RADIUS);
+            assertEquals(150, pos.getX(), "X should be player + distance");
+            assertEquals(50, pos.getZ(), "Z should stay at player Z");
+        }
+
+        @Test
+        void clampedWhenPlayerNearPositiveEdge() {
+            BlockPos pos = SpawnLocationHelper.computeTargetPosition(280, 0, 0, 100, CONFIGURED_MAX_WORLD_RADIUS);
+            assertEquals(CONFIGURED_MAX_WORLD_RADIUS - 1, pos.getX(),
+                    "X should be clamped to maxWorldRadius - 1");
+        }
+
+        @Test
+        void clampedInNegativeDirection() {
+            BlockPos pos = SpawnLocationHelper.computeTargetPosition(-280, 0, Math.PI, 100,
+                    CONFIGURED_MAX_WORLD_RADIUS);
+            assertEquals(-CONFIGURED_MAX_WORLD_RADIUS + 1, pos.getX(),
+                    "X should be clamped to -maxWorldRadius + 1");
+        }
+
+        @Test
+        void clampedOnBothAxes() {
+            double angle = Math.PI / 4; // northeast
+            BlockPos pos = SpawnLocationHelper.computeTargetPosition(280, 280, angle, 200,
+                    CONFIGURED_MAX_WORLD_RADIUS);
+            assertTrue(pos.getX() <= CONFIGURED_MAX_WORLD_RADIUS - 1,
+                    "X should be clamped, but was " + pos.getX());
+            assertTrue(pos.getZ() <= CONFIGURED_MAX_WORLD_RADIUS - 1,
+                    "Z should be clamped, but was " + pos.getZ());
+        }
+
+        @Test
+        void staysWithinBoundsForAllDirections() {
+            for (int degrees = 0; degrees < 360; degrees += 15) {
+                double angle = Math.toRadians(degrees);
+                BlockPos pos = SpawnLocationHelper.computeTargetPosition(0, 0, angle, 500,
+                        CONFIGURED_MAX_WORLD_RADIUS);
+                assertTrue(
+                        pos.getX() >= -CONFIGURED_MAX_WORLD_RADIUS + 1
+                                && pos.getX() <= CONFIGURED_MAX_WORLD_RADIUS - 1,
+                        "X out of bounds at " + degrees + " degrees: " + pos.getX());
+                assertTrue(
+                        pos.getZ() >= -CONFIGURED_MAX_WORLD_RADIUS + 1
+                                && pos.getZ() <= CONFIGURED_MAX_WORLD_RADIUS - 1,
+                        "Z out of bounds at " + degrees + " degrees: " + pos.getZ());
+            }
+        }
+
+        @Test
+        void playerAlreadyAtBorder() {
+            BlockPos pos = SpawnLocationHelper.computeTargetPosition(287, 287, 0, 50, CONFIGURED_MAX_WORLD_RADIUS);
+            assertEquals(CONFIGURED_MAX_WORLD_RADIUS - 1, pos.getX());
+            assertTrue(pos.getZ() <= CONFIGURED_MAX_WORLD_RADIUS - 1);
+        }
+    }
+
+    // --- computePositionInFrontOf ---
+
+    @Nested
+    class PositionInFrontOf {
+
+        @Test
+        void offsetAlongLookDirectionEast() {
+            // Looking east: lookAngleX=1, lookAngleZ=0
+            Vec3 pos = SpawnLocationHelper.computePositionInFrontOf(10, 65, 20, 1.0, 0.0, 3);
+            assertEquals(13.0, pos.x, 0.001, "X should be player + distance * lookAngleX");
+            assertEquals(68.0, pos.y, 0.001, "Y should be player + distance");
+            assertEquals(20.0, pos.z, 0.001, "Z should be unchanged when lookAngleZ is 0");
+        }
+
+        @Test
+        void offsetAlongLookDirectionSouth() {
+            // Looking south: lookAngleX=0, lookAngleZ=1
+            Vec3 pos = SpawnLocationHelper.computePositionInFrontOf(10, 65, 20, 0.0, 1.0, 3);
+            assertEquals(10.0, pos.x, 0.001, "X should be unchanged when lookAngleX is 0");
+            assertEquals(68.0, pos.y, 0.001, "Y should be player + distance");
+            assertEquals(23.0, pos.z, 0.001, "Z should be player + distance * lookAngleZ");
+        }
+
+        @Test
+        void diagonalLookDirection() {
+            // Looking northeast at 45 degrees: lookAngleX ≈ 0.707, lookAngleZ ≈ -0.707
+            double d = Math.sqrt(2) / 2;
+            Vec3 pos = SpawnLocationHelper.computePositionInFrontOf(0, 70, 0, d, -d, 4);
+            assertEquals(4 * d, pos.x, 0.001, "X should be offset by distance * lookAngleX");
+            assertEquals(74.0, pos.y, 0.001, "Y should be player + distance");
+            assertEquals(-4 * d, pos.z, 0.001, "Z should be offset by distance * lookAngleZ");
+        }
+
+        @Test
+        void yAlwaysRisesByDistance() {
+            // Y is always player.Y + distance, regardless of look angle
+            Vec3 pos3 = SpawnLocationHelper.computePositionInFrontOf(0, 100, 0, 0, 0, 3);
+            Vec3 pos6 = SpawnLocationHelper.computePositionInFrontOf(0, 100, 0, 0, 0, 6);
+            assertEquals(103.0, pos3.y, 0.001, "Y should rise by 3");
+            assertEquals(106.0, pos6.y, 0.001, "Y should rise by 6");
+        }
+
+        @Test
+        void distanceSixForExplosionSpawn() {
+            // The explode method uses distance=6
+            Vec3 pos = SpawnLocationHelper.computePositionInFrontOf(50, 80, 50, 1.0, 0.0, 6);
+            assertEquals(56.0, pos.x, 0.001);
+            assertEquals(86.0, pos.y, 0.001);
+            assertEquals(50.0, pos.z, 0.001);
+        }
+
+        @Test
+        void distanceThreeForChickenSpawn() {
+            // The event method uses distance=3
+            Vec3 pos = SpawnLocationHelper.computePositionInFrontOf(50, 80, 50, 1.0, 0.0, 3);
+            assertEquals(53.0, pos.x, 0.001);
+            assertEquals(83.0, pos.y, 0.001);
+            assertEquals(50.0, pos.z, 0.001);
+        }
+
+        @Test
+        void negativePlayerPosition() {
+            Vec3 pos = SpawnLocationHelper.computePositionInFrontOf(-100, 40, -200, 1.0, 1.0, 5);
+            assertEquals(-95.0, pos.x, 0.001);
+            assertEquals(45.0, pos.y, 0.001);
+            assertEquals(-195.0, pos.z, 0.001);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Reduce `MINECRAFT_MAX_WORLD_SIZE` from 299 to 288
- Update respawn logic to query the world border size at runtime instead of using hardcoded distances
- Clamp respawn positions to stay within the world border bounds

## Test plan
- [ ] Start the Minecraft server and verify the world border is 288 blocks
- [ ] Trigger a respawn and confirm the new position is within the world border
- [ ] Verify respawn positions are at least 30 blocks from the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)