### PR TITLE
fix: add required permissions to release-prepare workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -14,6 +14,8 @@ permissions:
   attestations: write
   id-token: write
   contents: read
+  attestations: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description
Fixes the workflow validation error in .

## Changes
- Added  permission
- Added  permission

## Reason
The reusable workflow  requires these permissions for attestations and ID token operations. Without these permissions, the workflow fails with:

> Error calling workflow 'quarkiverse/.github/.github/workflows/perform-release.yml@main'. The workflow is requesting 'attestations: write, id-token: write', but is only allowed 'attestations: none, id-token: none'.