### PR TITLE
Fix native compilation failure caused by RetryUtils static Random

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -40,6 +41,12 @@ class MinecrafterProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> producer) {
+        // RetryUtils has a static Random field that GraalVM disallows in the image heap
+        producer.produce(new RuntimeInitializedClassBuildItem("dev.langchain4j.internal.RetryUtils"));
     }
 
     @Record(STATIC_INIT)


### PR DESCRIPTION
## Summary
- GraalVM native-image build fails because `dev.langchain4j.internal.RetryUtils` has a static `java.util.Random` field that gets captured in the image heap at build time
- GraalVM rejects this because `Random` instances initialized at build time have cached seeds, breaking randomness at runtime
- Adds a `RuntimeInitializedClassBuildItem` for `RetryUtils` so the class is initialized at run time instead

Fixes the failure seen in https://github.com/quarkiverse/quarkus-observability-minecraft/actions/runs/24517445760/job/71665407008

## Test plan
- [ ] Verify the Quarkus ecosystem CI native build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)