### PR TITLE
Fix TodoResourceIT Content-Type assertion to fix ecosystem CI failure

### DIFF
--- a/sample/src/test/java/io/quarkus/sample/TodoResourceIT.java
+++ b/sample/src/test/java/io/quarkus/sample/TodoResourceIT.java
@@ -29,7 +29,7 @@ public class TodoResourceIT {
         // No data inserted.
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(0, todos.size());
     }
@@ -47,14 +47,14 @@ public class TodoResourceIT {
                 .post("/api")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(false))
                 .body("id", is(1));
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(1, todos.size());
     }
@@ -74,7 +74,7 @@ public class TodoResourceIT {
                 .patch("/api/{id}")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(true))
                 .body("id", is(1));
@@ -94,7 +94,7 @@ public class TodoResourceIT {
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(0, todos.size());
     }


### PR DESCRIPTION
## Summary
- Latest Quarkus snapshot now returns `Content-Type: application/json;charset=UTF-8` instead of `application/json`
- `TodoResourceIT` used `.header(HttpHeaders.CONTENT_TYPE, ...)` for response assertions, which does exact string matching and fails with the charset suffix
- Changed to `.contentType(...)` which does a contains check, matching the pattern already used in `TodoResourceTest`

## Test plan
- [x] Compiles cleanly
- [ ] CI passes with latest Quarkus snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)