### PR TITLE
Change naming from examplemod to quarkiversemod

### DIFF
--- a/modded-minecraft/build.gradle
+++ b/modded-minecraft/build.gradle
@@ -49,10 +49,10 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            property 'forge.enabledGameTestNamespaces', 'examplemod'
+            property 'forge.enabledGameTestNamespaces', 'quarkiversemod'
 
             mods {
-                examplemod {
+                quarkiversemod {
                     source sourceSets.main
                 }
             }
@@ -65,10 +65,10 @@ minecraft {
 
             property 'forge.logging.console.level', 'debug'
 
-            property 'forge.enabledGameTestNamespaces', 'examplemod'
+            property 'forge.enabledGameTestNamespaces', 'quarkiversemod'
 
             mods {
-                examplemod {
+                quarkiversemod {
                     source sourceSets.main
                 }
             }
@@ -84,10 +84,10 @@ minecraft {
 
             property 'forge.logging.console.level', 'debug'
 
-            property 'forge.enabledGameTestNamespaces', 'examplemod'
+            property 'forge.enabledGameTestNamespaces', 'quarkiversemod'
 
             mods {
-                examplemod {
+                quarkiversemod {
                     source sourceSets.main
                 }
             }
@@ -101,10 +101,10 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+            args '--mod', 'quarkiversemod', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
 
             mods {
-                examplemod {
+                quarkiversemod {
                     source sourceSets.main
                 }
             }
@@ -160,7 +160,7 @@ dependencies {
 jar {
     manifest {
         attributes([
-                "Specification-Title"     : "examplemod",
+                "Specification-Title"     : "quarkiversemod",
                 "Specification-Vendor"    : "Quarkiverse",
                 "Specification-Version"   : "1", // We are version 1 of ourselves
                 "Implementation-Title"    : project.name,

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Application.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Application.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/ClientSetup.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/ClientSetup.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.sounds.SoundSource;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Colour.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Colour.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 public class Colour {
     private final float r;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/CustomEntity.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/CustomEntity.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Endpoint.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Endpoint.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/EntityTypesInit.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/EntityTypesInit.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -11,7 +11,7 @@ public class EntityTypesInit {
     //    private static final DeferredRegister<EntityType<?>> BLOCKS = DeferredRegister.create(ENTITY_TYPES, MOD_ID);
 
     public static final DeferredRegister<EntityType<?>> ENTITY_TYPES = DeferredRegister.create(ForgeRegistries.ENTITY_TYPES,
-            ExampleMod.MOD_ID);
+            QuarkiverseMod.MOD_ID);
 
     public static final RegistryObject<EntityType<Wuff>> CRAB_ENTITY = ENTITY_TYPES.register("crab",
             () -> createStandardEntityType("crab", Wuff::new, MobCategory.CREATURE, 1.3f, 1.8f));
@@ -22,7 +22,7 @@ public class EntityTypesInit {
     //                        .sized(1.0F, 2.0F)
     //                        .fireImmune()
     //                        .updateInterval(1)
-    //                        .build("examplemod:example_monster");
+    //                        .build("quarkiversemod:example_monster");
     //                return CUSTOM_ENTITY_TYPE;
     //            });
 
@@ -31,6 +31,6 @@ public class EntityTypesInit {
             float height) {
         return EntityType.Builder.of(factory, classification)
                 .sized(width, height)
-                .build(ExampleMod.MOD_ID + ":" + entity_name);
+                .build(QuarkiverseMod.MOD_ID + ":" + entity_name);
     }
 }

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Listener.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Listener.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import java.net.InetAddress;
 

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Pattern.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Pattern.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 public enum Pattern {
     PLAIN,

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/PlainStringMessageBodyWriter.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/PlainStringMessageBodyWriter.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -20,8 +20,8 @@ import jakarta.ws.rs.ext.Provider;
  * and classloader shenanigans.
  */
 @Provider
-@Produces("text/html")
-public class StringMessageBodyWriter implements MessageBodyWriter<String> {
+@Produces("text/plain")
+public class PlainStringMessageBodyWriter implements MessageBodyWriter<String> {
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType,

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/PlayerWrapper.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/PlayerWrapper.java
@@ -1,6 +1,6 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
-import static com.example.examplemod.EntityTypesInit.CRAB_ENTITY;
+import static io.quarkiverse.observability.minecraft.mod.EntityTypesInit.CRAB_ENTITY;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/QuarkiverseMod.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/QuarkiverseMod.java
@@ -1,6 +1,6 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
-import static com.example.examplemod.EntityTypesInit.CRAB_ENTITY;
+import static io.quarkiverse.observability.minecraft.mod.EntityTypesInit.CRAB_ENTITY;
 
 import java.util.stream.Collectors;
 
@@ -33,19 +33,19 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegisterEvent;
 
 // The value here should match an entry in the META-INF/mods.toml file
-@Mod("examplemod")
-public class ExampleMod {
+@Mod("quarkiversemod")
+public class QuarkiverseMod {
     // Directly reference a slf4j logger
     private static final Logger LOGGER = LogUtils.getLogger();
 
     static EntityType CUSTOM_ENTITY_TYPE;
 
-    static final String MOD_ID = "examplemod";
+    static final String MOD_ID = "quarkiversemod";
 
     public static final DeferredRegister<EntityDataSerializer<?>> ENTITY_DATA_SERIALIZERS = DeferredRegister
-            .create(ForgeRegistries.Keys.ENTITY_DATA_SERIALIZERS, ExampleMod.MOD_ID);
+            .create(ForgeRegistries.Keys.ENTITY_DATA_SERIALIZERS, QuarkiverseMod.MOD_ID);
 
-    public ExampleMod() {
+    public QuarkiverseMod() {
         // Register the setup method for modloading
         IEventBus bus = FMLJavaModLoadingContext.get()
                 .getModEventBus();
@@ -76,7 +76,7 @@ public class ExampleMod {
     @SubscribeEvent
     public void enqueueIMC(final InterModEnqueueEvent event) {
         // Some example code to dispatch IMC to another mod
-        InterModComms.sendTo("examplemod", "helloworld", () -> {
+        InterModComms.sendTo("quarkiversemod", "helloworld", () -> {
             LOGGER.info("Hello world from the MDK");
             return "Hello world";
         });

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/SpawnLocationHelper.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/SpawnLocationHelper.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/StringMessageBodyReader.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/StringMessageBodyReader.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import java.io.BufferedReader;
 import java.io.InputStream;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/StringMessageBodyWriter.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/StringMessageBodyWriter.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -20,8 +20,8 @@ import jakarta.ws.rs.ext.Provider;
  * and classloader shenanigans.
  */
 @Provider
-@Produces("text/plain")
-public class PlainStringMessageBodyWriter implements MessageBodyWriter<String> {
+@Produces("text/html")
+public class StringMessageBodyWriter implements MessageBodyWriter<String> {
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType,

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Wuff.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/Wuff.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.syncher.EntityDataAccessor;

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/WuffModel.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/WuffModel.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import com.google.common.collect.ImmutableList;
 

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/WuffRenderer.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/WuffRenderer.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 
@@ -13,15 +13,15 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 @OnlyIn(Dist.CLIENT)
 public class WuffRenderer extends MobRenderer<Wuff, WuffModel<Wuff>> {
 
-    protected static final ResourceLocation WOLF_LOCATION = new ResourceLocation(ExampleMod.MOD_ID,
+    protected static final ResourceLocation WOLF_LOCATION = new ResourceLocation(QuarkiverseMod.MOD_ID,
             "textures/entity/wuff.png");
-    protected static final ResourceLocation WOLF_LOCATION_WHITE_SPOT = new ResourceLocation(ExampleMod.MOD_ID,
+    protected static final ResourceLocation WOLF_LOCATION_WHITE_SPOT = new ResourceLocation(QuarkiverseMod.MOD_ID,
             "textures/entity/wuff-white-spot.png");
-    protected static final ResourceLocation WOLF_LOCATION_BLACK_SPOT = new ResourceLocation(ExampleMod.MOD_ID,
+    protected static final ResourceLocation WOLF_LOCATION_BLACK_SPOT = new ResourceLocation(QuarkiverseMod.MOD_ID,
             "textures/entity/wuff-black-spot.png");
-    protected static final ResourceLocation WOLF_LOCATION_STRIPES = new ResourceLocation(ExampleMod.MOD_ID,
+    protected static final ResourceLocation WOLF_LOCATION_STRIPES = new ResourceLocation(QuarkiverseMod.MOD_ID,
             "textures/entity/wuff-stripe.png");
-    protected static final ResourceLocation WOLF_LOCATION_SPECTRAL_STRIPES = new ResourceLocation(ExampleMod.MOD_ID,
+    protected static final ResourceLocation WOLF_LOCATION_SPECTRAL_STRIPES = new ResourceLocation(QuarkiverseMod.MOD_ID,
             "textures/entity/wuff-spectral.png");
 
     public WuffRenderer(EntityRendererProvider.Context p_174452_) {

--- a/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/WuffStuff.java
+++ b/modded-minecraft/src/main/java/io/quarkiverse/observability/minecraft/mod/WuffStuff.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 public class WuffStuff {
 

--- a/modded-minecraft/src/main/resources/META-INF/mods.toml
+++ b/modded-minecraft/src/main/resources/META-INF/mods.toml
@@ -15,19 +15,19 @@ license="All rights reserved"
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
-modId="examplemod" #mandatory
+modId="quarkiversemod" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
 version="${file.jarVersion}" #mandatory
  # A display name for the mod
-displayName="Example Mod" #mandatory
+displayName="Quarkiverse Mod" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/
 #updateJSONURL="https://change.me.example.invalid/updates.json" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
 #displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
-logoFile="examplemod.png" #optional
+logoFile="quarkiversemod.png" #optional
 # A text field displayed in the mod UI
 credits="Thanks for this example mod goes to Java" #optional
 # A text field displayed in the mod UI
@@ -49,7 +49,7 @@ Have some lorem ipsum.
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed mollis lacinia magna. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed sagittis luctus odio eu tempus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Pellentesque volutpat ligula eget lacus auctor sagittis. In hac habitasse platea dictumst. Nunc gravida elit vitae sem vehicula efficitur. Donec mattis ipsum et arcu lobortis, eleifend sagittis sem rutrum. Cras pharetra quam eget posuere fermentum. Sed id tincidunt justo. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.examplemod]] #optional
+[[dependencies.quarkiversemod]] #optional
     # the modid of the dependency
     modId="forge" #mandatory
     # Does this dependency have to exist - if not, ordering below must be specified
@@ -61,7 +61,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed mollis lacinia magn
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
     side="BOTH"
 # Here's another dependency
-[[dependencies.examplemod]]
+[[dependencies.quarkiversemod]]
     modId="minecraft"
     mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version

--- a/modded-minecraft/src/main/resources/pack.mcmeta
+++ b/modded-minecraft/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "examplemod resources",
+        "description": "quarkiversemod resources",
         "pack_format": 9
     }
 }

--- a/modded-minecraft/src/test/java/io/quarkiverse/observability/minecraft/mod/SpawnLocationHelperTest.java
+++ b/modded-minecraft/src/test/java/io/quarkiverse/observability/minecraft/mod/SpawnLocationHelperTest.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package io.quarkiverse.observability.minecraft.mod;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
Naming is hard, but `examplemod` clearly had to go. I went with `quarkiversemod`.