### PR TITLE
Do not use reuse on tests to avoid orphaned containers

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecraftContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecraftContainer.java
@@ -17,11 +17,11 @@ public class MinecraftContainer extends GenericContainer<MinecraftContainer> imp
     private static final DockerImageName dockerImageName = DockerImageName.parse("minecraft-server");
     private final int minecraftApiPort;
 
-    public MinecraftContainer(final int minecraftApiPort, Optional<Integer> devServicesPort) {
+    public MinecraftContainer(final int minecraftApiPort, Optional<Integer> devServicesPort, boolean reuse) {
         super(dockerImageName);
         this.minecraftApiPort = minecraftApiPort;
         this.waitingFor(Wait.forLogMessage(".*" + "Preparing" + ".*", 1))
-                .withReuse(true)
+                .withReuse(reuse)
                 .withExposedPorts(minecraftApiPort, minecraftGamePort);
 
         devServicesPort.ifPresent(port -> {

--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterDevServicesConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterDevServicesConfig.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 @ConfigMapping(prefix = "quarkus.minecrafter")
@@ -21,7 +22,13 @@ public interface MinecrafterDevServicesConfig {
          * If not set, an ephemeral host port is used.
          */
         Optional<Integer> port();
+
+        /**
+         * Whether to reuse the container across test runs.
+         * If true, the container will be kept running after tests complete.
+         * Defaults to true for faster test iterations during development.
+         */
+        @WithDefault("true")
+        boolean reuse();
     }
 }
-
-// Made with Bob

--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
@@ -125,9 +125,11 @@ class MinecrafterProcessor {
 
         final int minecraftApiPort = 8081;
 
+        MinecrafterDevServicesConfig.DevServices devservicesConfig = config.devservices();
         return DevServicesResultBuildItem.owned()
                 .feature(FEATURE)
-                .startable(() -> new MinecraftContainer(minecraftApiPort, config.devservices().port()))
+                .startable(() -> new MinecraftContainer(minecraftApiPort, devservicesConfig.port(),
+                        devservicesConfig.reuse()))
                 .configProvider(Map.of("quarkus.minecrafter.base-url",
                         c -> "http://" + c.getHost() + ":" + c.getMappedPort(minecraftApiPort)))
                 .build();

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
               <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
               <maven.home>${maven.home}</maven.home>
               <maven.repo>${settings.localRepository}</maven.repo>
+              <quarkus.minecrafter.devservices.reuse>false</quarkus.minecrafter.devservices.reuse>
+              <quarkus.datasource.devservices.reuse>false</quarkus.datasource.devservices.reuse>
             </systemPropertyVariables>
           </configuration>
         </plugin>


### PR DESCRIPTION
I'm not totally sure why all of Quarkus doesn't have this problem, but we hardcoded reuse to true which wasn't ideal, so making it more flexible, and then using the flexibility. 