### PR TITLE
Downgrade to more sensible 'built with'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse</groupId>
@@ -24,7 +25,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.36.2</quarkus.version>
+    <quarkus.version>3.36.0</quarkus.version>
     <surefire-plugin.version>3.5.5</surefire-plugin.version>
     <langchain4j-version>1.15.0</langchain4j-version>
   </properties>


### PR DESCRIPTION
I noticed that when I use `quarkus ext add` I get minecraft 0.9.0. I'm hoping using an older version of Quarkus in my parent pom will sort that out. (Updating the sample to Quarkus 3.36.2 did sort it out, but I'd like to fix at the extension level.)