### PR TITLE
Remove action that was having no effect

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,6 +30,3 @@ jobs:
       - name: Build todo app
         run: mvn install
         working-directory: sample
-      - uses: dineshsonachalam/markdown-autodocs@v1.0.7
-        with:
-          output_file_paths: '[./demo-script.md]'


### PR DESCRIPTION
Third-party actions are now banned in the quarkiverse. I almost replaced this action with a Bob-coded jbang replacement, then I realised the demo script had no toc and the action was doing nothing. 