### PR TITLE
Check config before starting Minecraft dev service

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterDevServicesConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterDevServicesConfig.java
@@ -18,6 +18,14 @@ public interface MinecrafterDevServicesConfig {
 
     interface DevServices {
         /**
+         * Whether the Minecraft dev service is enabled.
+         * Dev Services is generally enabled by default, unless an existing
+         * {@code quarkus.minecrafter.base-url} is configured.
+         */
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
          * Fixed host port to expose the Minecraft game server on.
          * If not set, an ephemeral host port is used.
          */

--- a/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/observability/minecraft/deployment/MinecrafterProcessor.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import jakarta.ws.rs.Priorities;
 
 import org.jboss.jandex.DotName;
+import org.jboss.logging.Logger;
 
 import io.quarkiverse.observability.minecraft.runtime.*;
 import io.quarkiverse.observability.minecraft.runtime.ai.LLMWuffMaker;
@@ -31,10 +32,14 @@ import io.quarkus.devui.spi.page.CardAction;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
+import io.quarkus.runtime.configuration.ConfigUtils;
 
 class MinecrafterProcessor {
 
+    private static final Logger log = Logger.getLogger(MinecrafterProcessor.class);
+
     private static final String FEATURE = "minecrafter";
+    private static final String BASE_URL_CONFIG_KEY = "quarkus.minecrafter.base-url";
     private static final DotName JAX_RS_GET = DotName.createSimple("jakarta.ws.rs.GET");
     private static final DotName JAX_RS_POST = DotName.createSimple("jakarta.ws.rs.POST");
     private static final DotName JAX_RS_PUT = DotName.createSimple("jakarta.ws.rs.PUT");
@@ -134,14 +139,25 @@ class MinecrafterProcessor {
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     public DevServicesResultBuildItem createContainer(MinecrafterDevServicesConfig config) {
 
+        MinecrafterDevServicesConfig.DevServices devservicesConfig = config.devservices();
+
+        if (!devservicesConfig.enabled()) {
+            log.debug("Not starting Dev Services for Minecraft as it has been disabled in the config");
+            return null;
+        }
+
+        if (ConfigUtils.isPropertyNonEmpty(BASE_URL_CONFIG_KEY)) {
+            log.debug("Not starting Dev Services for Minecraft as a base URL has been provided");
+            return null;
+        }
+
         final int minecraftApiPort = 8081;
 
-        MinecrafterDevServicesConfig.DevServices devservicesConfig = config.devservices();
         return DevServicesResultBuildItem.owned()
                 .feature(FEATURE)
                 .startable(() -> new MinecraftContainer(minecraftApiPort, devservicesConfig.port(),
                         devservicesConfig.reuse()))
-                .configProvider(Map.of("quarkus.minecrafter.base-url",
+                .configProvider(Map.of(BASE_URL_CONFIG_KEY,
                         c -> "http://" + c.getHost() + ":" + c.getMappedPort(minecraftApiPort)))
                 .build();
 

--- a/deployment/src/test/java/io/quarkiverse/observability/minecraft/test/MinecrafterDevServicesDisabledTest.java
+++ b/deployment/src/test/java/io/quarkiverse/observability/minecraft/test/MinecrafterDevServicesDisabledTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.observability.minecraft.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MinecrafterDevServicesDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.minecrafter.devservices.enabled", "false");
+
+    @Test
+    public void devServiceShouldNotStartWhenDisabled() {
+        String baseUrl = ConfigProvider.getConfig()
+                .getValue("quarkus.minecrafter.base-url", String.class);
+        assertEquals("http://localhost:8081/", baseUrl);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/observability/minecraft/test/MinecrafterDevServicesExistingConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/observability/minecraft/test/MinecrafterDevServicesExistingConfigTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.observability.minecraft.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MinecrafterDevServicesExistingConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.minecrafter.base-url", "http://my-server:8081");
+
+    @Test
+    public void devServiceShouldNotStartWhenBaseUrlIsConfigured() {
+        String baseUrl = ConfigProvider.getConfig()
+                .getValue("quarkus.minecrafter.base-url", String.class);
+        assertEquals("http://my-server:8081", baseUrl);
+    }
+}


### PR DESCRIPTION
Skip starting the dev service container when the extension's dev service is explicitly disabled or when an existing base URL is already configured. Follows the standard Quarkus dev services guard pattern used by Redis, Kafka, etc.

Resolves #37